### PR TITLE
Corrected join to not run forever

### DIFF
--- a/macros/dimensional_dbt_internals/partials.sql
+++ b/macros/dimensional_dbt_internals/partials.sql
@@ -45,10 +45,11 @@
         source.{{ unique_key }} = deduplicated.dimensional_dbt_unique_key
     AND
         source.dbt_updated_at = deduplicated.dbt_updated_at
-    JOIN
+    LEFT JOIN
     earliest_{{ source }}
     ON 
-        1=1
+        earliest_{{ source }}.dimensional_dbt_unique_key = deduplicated.dimensional_dbt_unique_key
+
     WHERE 
         dimensional_dbt_recency = 1
 {%- endmacro -%}


### PR DESCRIPTION
## Expected
Joins are not insalenly wasteful and spilly.

## Actual
The earliest record is NOT a scalar value, so the 1=1 join is... explosive. and wrong.

## What does this do?
records build in the reasonably expected (many seconds) instead of forever.