### PR TITLE
supports partials now ;)

### DIFF
--- a/macros/dimensional_dbt.sql
+++ b/macros/dimensional_dbt.sql
@@ -1,17 +1,18 @@
-{%- macro column_selection(source_ctes, column_count) -%}
+{%- macro column_selection(source_ctes, column_count, partial=False) -%}
     {#/* The dimensional merge entrypoint where final select columns are defined.
         Note: this is intended to be used as a callback for a `call` block with a SELECT partial.
         Args:
             source_ctes: a list of CTE names either manually created or generated via `source_builder`. 
                 Each CTE will be merged into the final available sources for the select statement.
             column_count: The number of columns captured in the select.
+            partial: if true will build the table to resemble a DBT Snapshot (so you can join it again).
         Returns:
             A completed complex partial that wraps the calling SELECT with a CTE and complex FROM statement. 
             See the README for more details.
     */#}
     {{ dimensional_dbt.before_select(source_ctes) }}
     {{ caller() }}
-    {{ dimensional_dbt.after_select(source_ctes, column_count) }}
+    {{ dimensional_dbt.after_select(source_ctes, column_count, partial) }}
 {%- endmacro -%}
 
 

--- a/macros/dimensional_dbt_internals/abstraction.sql
+++ b/macros/dimensional_dbt_internals/abstraction.sql
@@ -15,6 +15,7 @@
         ,{{ dimensional_dbt.dim_columns() }}
     {% endif %}
     FROM
+        {#/* +3 is due to the extra columns above needed for a partial */#}
         {% set final_column_count = (column_count + 3) if partial else column_count %}
         {{ dimensional_dbt.from_clause(source_ctes, final_column_count) }}
 )

--- a/macros/dimensional_dbt_internals/partials.sql
+++ b/macros/dimensional_dbt_internals/partials.sql
@@ -148,3 +148,19 @@
     QUALIFY dim_valid_to IS NOT NULL 
     AND dim_valid_to <> dim_valid_from
 {%- endmacro -%}
+
+
+{%- macro coalesce_snapshot_cols(sources, col_suffix ) -%}
+    {#/* creates a coalesce statement from a list of dbt sources
+        for dbt snapshot columns.
+        Args:
+            sources: the source names to coalese
+            col_suffix: what type of dbt snapshot col is this?
+    */#}
+    COALESCE(
+        {% for source in sources %}
+            {{ source }}_d.dbt_{{col_suffix}}
+            {% if not loop.last %},{% endif %}
+        {% endfor %}
+    )
+{%- endmacro -%}

--- a/test_dimensional_dbt/models/dim_product_partial.sql
+++ b/test_dimensional_dbt/models/dim_product_partial.sql
@@ -1,0 +1,14 @@
+WITH
+
+{{ dimensional_dbt.source_builder('_stripe_source','chiquita_product_id::NUMBER', 'stripe') }}
+,{{ dimensional_dbt.source_builder(['snapshots', 'bluth_wms_inventory'], "REPLACE(vendor_id,'chi-','')::NUMBER", 'warehouse', "source") }}
+,{{ dimensional_dbt.source_builder('DIMENSIONAL_DBT_SNAPSHOTS.CHIQUITA_INVOICES','id::NUMBER', 'vendor', "raw") }}
+
+{% call dimensional_dbt.column_selection(['stripe','warehouse','vendor'], 5, partial=True) %}
+    SELECT 
+        stripe_d.name AS product_name
+        ,stripe_d.retail_price AS retail_price
+        ,vendor_d.wholesale_cost AS wholesale_cost
+        ,stripe_d.description AS description
+        ,IFNULL(warehouse_d.storage_type,'Storage Unkown') AS required_type_of_storage_in_warehouse
+{% endcall %}


### PR DESCRIPTION
## Why?
We need partials to do multi-key staged joins. 
so `vendor`+`account` on `account_id`, then the resulting `vendor-account` + `alchemy` on `opportunity_id`. 
This is very gnarly without help.. so now dimensional dbt helps! 

## What Changes?
passing `partial=true` creates the final relation as a mock DBT Snapshot so you can plug it into your next dimensional step of dimensional_dbt for more joins. 
This uses the first of the ctes because as long as you always use the same truncation (fixed to an hour at the moment) any CTE will work ;) 

## How Does This Impact Me/Us?
- we can build out staggered merges with different joining ids! 