### PR TITLE
feature/DATA-207/timestamp-bug | fixed other timestamp casts

### DIFF
--- a/macros/dimensional_dbt_internals/partials.sql
+++ b/macros/dimensional_dbt_internals/partials.sql
@@ -15,7 +15,7 @@
         earliest_{{ source }} AS (
             SELECT 
                 {{ unique_key }} AS dimensional_dbt_unique_key
-                , DATE_TRUNC('{{precision}}', MIN(dbt_updated_at))::TIMESTAMPNTZ AS earliest_dbt_updated_at
+                , DATE_TRUNC('{{precision}}', MIN(dbt_updated_at::TIMESTAMPNTZ)) AS earliest_dbt_updated_at
             FROM 
                 {{ source }}
             GROUP BY 1
@@ -36,7 +36,7 @@
             WHEN DATE_TRUNC('{{precision}}', dbt_valid_from::TIMESTAMPNTZ ) = earliest_dbt_updated_at THEN '0000-01-01'::TIMESTAMPNTZ
             ELSE DATE_TRUNC('{{precision}}', dbt_valid_from::TIMESTAMPNTZ )
         END AS dimensional_dbt_valid_from
-        ,IFNULL(DATE_TRUNC('{{precision}}', dbt_valid_to ), '9999-12-31'::TIMESTAMPNTZ) AS dimensional_dbt_valid_to
+        ,IFNULL(DATE_TRUNC('{{precision}}', dbt_valid_to::TIMESTAMPNTZ ), '9999-12-31'::TIMESTAMPNTZ) AS dimensional_dbt_valid_to
     FROM
         {{ source }} source
     RIGHT JOIN


### PR DESCRIPTION
## Why?
Because dbt_valid_to left to its own devices is deemed a variant by snowflake

## What Changes?
-  CAST ALL THE THINGS

## How Does This Impact Me/Us?
- WE WILL OVERCOME